### PR TITLE
Added repetition for multiple declarations/steps

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -168,10 +168,15 @@
 //!
 //! Like C loops, `cfor!` supports specfying multiple initializations and steps seperated by a comma.
 //!
+//! ```rust
+//! #[macro_use] extern crate cfor;
+//!
+//! fn main() {
+//!     cfor!{let mut x = 0, let mut y = x; x <= 10 && y <= 100; x += 1, y += 10; {
+//!         println!(x: {}, y: {}", x, y);
+//!     }}
+//! }
 //! ```
-//!cfor!(let mut x = 0, let mut y = x; x <= 10 && y <= 100; x+= 1, y += 10; {
-//!    println!("{}:{}", x, y);
-//!});
 
 
 /// A C-style `for` loop in macro form.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,7 +173,7 @@
 //!
 //! fn main() {
 //!     cfor!{let mut x = 0, let mut y = x; x <= 10 && y <= 100; x += 1, y += 10; {
-//!         println!(x: {}, y: {}", x, y);
+//!         println!("x: {}, y: {}", x, y);
 //!     }}
 //! }
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -163,6 +163,15 @@
 //! This is invoked in the same manner as `cfor!`, but, if `$body`
 //! contains a `continue`, the `$step` at the end of the loop body
 //! will never be evaluated.
+//! 
+//! # Handling multiple initializations and steps
+//!
+//! Like C loops, `cfor!` supports specfying multiple initializations and steps seperated by a comma.
+//!
+//! ```
+//!cfor!(let mut x = 0, let mut y = x; x <= 10 && y <= 100; x+= 1, y += 10; {
+//!    println!("{}:{}", x, y);
+//!});
 
 
 /// A C-style `for` loop in macro form.
@@ -175,20 +184,20 @@ macro_rules! cfor {
         cfor!((); $($rest)*)
     };
     // for ($init; ; ...) { ... }
-    ($init: stmt; ; $($rest: tt)*) => {
+    ($($init: stmt),+; ; $($rest: tt)*) => {
         // avoid the `while true` lint
-        cfor!($init; !false; $($rest)*)
+        cfor!($($init),+; !false; $($rest)*)
     };
 
     // for ($init; $cond; ) { ... }
-    ($init: stmt; $cond: expr; ; $body: block) => {
-        cfor!{$init; $cond; (); $body}
+    ($($init: stmt),+; $cond: expr; ; $body: block) => {
+        cfor!{$($init),+; $cond; (); $body}
     };
 
     // for ($init; $cond; $step) { $body }
-    ($init: stmt; $cond: expr; $step: expr; $body: block) => {
+    ($($init: stmt),+; $cond: expr; $($step: expr),+; $body: block) => {
         {
-            $init;
+            $($init;)+
             while $cond {
                 let mut _first = true;
                 let mut _continue = false;
@@ -215,7 +224,7 @@ macro_rules! cfor {
                     break
                 }
 
-                $step
+                $($step;)+
             }
         }
     };

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -45,3 +45,21 @@ fn missing_parts() {
         panic!()
     }}
 }
+
+#[test]
+fn multi_dec() {
+    cfor!(let x = true, let y = x, let z = false; false;; {
+        assert!(x);
+        assert_eq!(x, y);
+        assert!(!z);
+    });
+}
+
+#[test]
+fn multi_step() {
+    let mut x = 0;
+    let mut y = 0;
+    cfor!(; x < 10 && y < 100; x += 1, y += 10; {});
+    assert_eq!(x, 10);
+    assert_eq!(y, 100);
+}


### PR DESCRIPTION
One of the things I missed about C for loops was the ability to use multiple declarations and multiple steps like so:

```
for (size_t i = 0, y = 3; i < 10; i++, y+=4) {}
```

I did the best I could at translating the syntax to cfor:

```
cfor!(let mut x = 0, let mut y = 3; x < 10; x+=1, y+=1; {});
```
